### PR TITLE
Remove newline style forcing in .rustfmt.toml

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -3,7 +3,6 @@ merge_imports = true
 format_strings = true
 format_macro_matchers = true
 max_width = 120
-newline_style = "Unix"
 normalize_comments = true
 report_todo = "Always"
 report_fixme = "Always"


### PR DESCRIPTION
Git can take care about newline styles by itself. Also git can automatically convert LF to CRLF and back, so sometimes commits look like all files changed on Windows.