### PR TITLE
Get rid of Mutex in a webhook impl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ log = "0.4"
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"
 tokio = "0.1"
+tokio-sync = "0.1.3"
 tokio-timer = "0.2"
 typed-headers = "0.1"
 url = "1.7"

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -4,6 +4,7 @@ use hyper::Server;
 use std::net::SocketAddr;
 
 mod poll;
+mod queue;
 mod webhook;
 
 pub use self::{poll::*, webhook::*};

--- a/src/handler/queue.rs
+++ b/src/handler/queue.rs
@@ -1,0 +1,48 @@
+use crate::{types::Update, UpdateHandler};
+use futures::{Future, Stream};
+use hyper::rt::spawn;
+use tokio_sync::mpsc;
+
+/// A lazy updates processing queue.
+pub struct Queue {
+    sender: mpsc::Sender<Update>,
+    prepared_future: Option<Box<Future<Item = (), Error = ()> + Send>>,
+}
+
+impl Queue {
+    /// Prepares a queue with a given update handler.
+    ///
+    /// To launch the processing run `Queue::launch` when you are inside a tokio's context.
+    pub fn prepare<H>(mut update_handler: H) -> Self
+    where
+        H: UpdateHandler + Send + 'static,
+    {
+        const MAX_UPDATES_IN_QUEUE: usize = 10;
+        let (sender, receiver) = mpsc::channel(MAX_UPDATES_IN_QUEUE);
+        let processing = receiver
+            .map_err(|_| log::error!("Channel receive error"))
+            .for_each(move |update| {
+                update_handler.handle(update);
+                Ok(())
+            });
+        Queue {
+            sender,
+            prepared_future: Some(Box::new(processing)),
+        }
+    }
+
+    /// Clones the underlying sender and gives it away.
+    pub fn get_sender(&self) -> mpsc::Sender<Update> {
+        self.sender.clone()
+    }
+
+    /// Launches processing of an updates queue.
+    ///
+    /// # Panics
+    /// Should be launched from a tokio's context!
+    pub fn launch(&mut self) {
+        if let Some(fut) = self.prepared_future.take() {
+            spawn(fut);
+        }
+    }
+}

--- a/src/handler/webhook.rs
+++ b/src/handler/webhook.rs
@@ -1,28 +1,33 @@
-use crate::{types::Update, UpdateHandler};
-use futures::{future::ok, Future, Stream};
+use crate::{handler::queue::Queue, types::Update, UpdateHandler};
+use futures::{
+    future::{ok, Either},
+    Future, Sink, Stream,
+};
 use hyper::{
     header::{HeaderValue, ALLOW},
     service::{MakeService, Service},
     Body, Error, Method, Request, Response, StatusCode,
 };
-use std::{
-    error::Error as StdError,
-    fmt,
-    sync::{Arc, Mutex},
-};
+use std::{error::Error as StdError, fmt};
+use tokio_sync::mpsc;
 
 /// Creates a webhook service
-pub struct WebhookServiceFactory<H> {
+pub struct WebhookServiceFactory {
     path: String,
-    update_handler: Arc<Mutex<H>>,
+    queue: Queue,
 }
 
-impl<H> WebhookServiceFactory<H> {
+impl WebhookServiceFactory {
     /// Creates a new factory
-    pub fn new<S: Into<String>>(path: S, update_handler: H) -> WebhookServiceFactory<H> {
+    pub fn new<S, H>(path: S, update_handler: H) -> WebhookServiceFactory
+    where
+        S: Into<String>,
+        H: UpdateHandler + Send + Sync + 'static,
+    {
+        let queue = Queue::prepare(update_handler);
         WebhookServiceFactory {
             path: path.into(),
-            update_handler: Arc::new(Mutex::new(update_handler)),
+            queue,
         }
     }
 }
@@ -39,64 +44,76 @@ impl fmt::Display for WebhookServiceFactoryError {
 
 impl StdError for WebhookServiceFactoryError {}
 
-impl<Ctx, H> MakeService<Ctx> for WebhookServiceFactory<H>
-where
-    H: UpdateHandler + Send + Sync + 'static,
-{
+impl<Ctx> MakeService<Ctx> for WebhookServiceFactory {
     type ReqBody = Body;
     type ResBody = Body;
     type Error = Error;
-    type Service = WebhookService<H>;
+    type Service = WebhookService;
     type Future = Box<Future<Item = Self::Service, Error = Self::MakeError> + Send>;
     type MakeError = WebhookServiceFactoryError;
 
     fn make_service(&mut self, _ctx: Ctx) -> Self::Future {
-        Box::new(ok(WebhookService {
-            path: self.path.clone(),
-            update_handler: self.update_handler.clone(),
-        }))
+        let path = self.path.clone();
+        let queue = self.queue.get_sender();
+        self.queue.launch();
+        Box::new(ok(WebhookService { path, queue }))
     }
 }
 
 /// Webhook service
-pub struct WebhookService<H> {
+pub struct WebhookService {
     path: String,
-    update_handler: Arc<Mutex<H>>,
+    queue: mpsc::Sender<Update>,
 }
 
-impl<H> Service for WebhookService<H>
-where
-    H: UpdateHandler + Send + Sync + 'static,
-{
+fn put_on_a_queue(
+    request: Request<Body>,
+    queue: mpsc::Sender<Update>,
+) -> impl Future<Item = Response<Body>, Error = Error> {
+    request
+        .into_body()
+        .concat2()
+        .and_then(move |body| match serde_json::from_slice(&body) {
+            Ok(update) => Either::A(queue.send(update).then(|res| {
+                if res.is_err() {
+                    log::warn!("The receiving end has been dropped");
+                    Ok(Response::builder()
+                        .status(StatusCode::INTERNAL_SERVER_ERROR)
+                        .body(Body::empty())
+                        .expect("Can't construct an INTERNAL_SERVER_ERROR response"))
+                } else {
+                    Ok(Response::new(Body::empty()))
+                }
+            })),
+            Err(err) => Either::B(ok(Response::builder()
+                .status(StatusCode::BAD_REQUEST)
+                .body(Body::from(err.to_string()))
+                .expect("Can't construct a BAD_REQUEST response"))),
+        })
+}
+
+impl Service for WebhookService {
     type ReqBody = Body;
     type ResBody = Body;
     type Error = Error;
     type Future = Box<Future<Item = Response<Body>, Error = Error> + Send>;
 
     fn call(&mut self, req: Request<Self::ReqBody>) -> Self::Future {
-        let mut rep = Response::new(Body::empty());
         if let Method::POST = *req.method() {
             if req.uri().path() == self.path {
-                let update_handler = self.update_handler.clone();
-                return Box::new(req.into_body().concat2().map(move |body| {
-                    match serde_json::from_slice::<Update>(&body) {
-                        Ok(update) => {
-                            update_handler.lock().unwrap().handle(update);
-                        }
-                        Err(err) => {
-                            *rep.status_mut() = StatusCode::BAD_REQUEST;
-                            *rep.body_mut() = err.to_string().into();
-                        }
-                    }
-                    rep
-                }));
+                Box::new(put_on_a_queue(req, self.queue.clone()))
             } else {
-                *rep.status_mut() = StatusCode::NOT_FOUND;
+                Box::new(ok(Response::builder()
+                    .status(StatusCode::NOT_FOUND)
+                    .body(Body::empty())
+                    .expect("Can't construct a NOT_FOUND response")))
             }
         } else {
-            *rep.status_mut() = StatusCode::METHOD_NOT_ALLOWED;
-            rep.headers_mut().insert(ALLOW, HeaderValue::from_static("POST"));
+            Box::new(ok(Response::builder()
+                .status(StatusCode::METHOD_NOT_ALLOWED)
+                .header(ALLOW, HeaderValue::from_static("POST"))
+                .body(Body::empty())
+                .expect("Can't construct a METHOD_NOT_ALLOWED response")))
         }
-        Box::new(ok(rep))
     }
 }


### PR DESCRIPTION
Replace a mutex with a separate task that is driven by incoming messages using a `tokio_sync::mpsc` bounded channel.