### PR TITLE
Add limit to `spawn`'ed tasks count in `LongPoll`

### DIFF
--- a/tests/longpoll.rs
+++ b/tests/longpoll.rs
@@ -1,6 +1,9 @@
 #![allow(missing_docs)]
 use std::{
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
     time::{Duration, Instant},
 };
 
@@ -9,7 +12,7 @@ use mockito::{Matcher, Server};
 use serde_json::json;
 use tgbot::{
     api::Client,
-    handler::{LongPoll, UpdateHandler},
+    handler::{LongPoll, LongPollOptions, UpdateHandler},
     types::Update,
 };
 use tokio::{spawn, sync::Mutex, time::sleep};
@@ -90,4 +93,73 @@ async fn longpoll() {
     });
     poll.run().await;
     assert!(!updates.lock().await.is_empty())
+}
+
+struct BoundedHandler {
+    active: Arc<AtomicUsize>,
+    max_active: Arc<AtomicUsize>,
+}
+
+impl UpdateHandler for BoundedHandler {
+    async fn handle(&self, _update: Update) {
+        let count = self.active.fetch_add(1, Ordering::AcqRel) + 1;
+        self.max_active.fetch_max(count, Ordering::AcqRel);
+
+        sleep(Duration::from_millis(20)).await;
+
+        self.active.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
+#[tokio::test]
+async fn longpoll_concurrency_limit() {
+    let mut server = Server::new_async().await;
+
+    let updates: Vec<serde_json::Value> = (0..10)
+        .map(|i| {
+            json!({
+                "update_id": i,
+                "message": {
+                    "message_id": 1,
+                    "date": 0,
+                    "from": {"id": 1, "is_bot": false, "first_name": "test"},
+                    "chat": {"id": 1, "type": "private", "first_name": "test"},
+                    "text": "test"
+                }
+            })
+        })
+        .collect();
+
+    server
+        .mock("POST", "/bot-token/getUpdates")
+        .with_body(
+            serde_json::to_vec(&json!({
+                "ok": true,
+                "result": updates
+            }))
+            .unwrap(),
+        )
+        .create();
+
+    let client = Client::new("-token").unwrap().with_host(server.url());
+    let max_active = Arc::new(AtomicUsize::default());
+    let handler = BoundedHandler {
+        active: Default::default(),
+        max_active: max_active.clone(),
+    };
+
+    let limit = 3;
+    let options = LongPollOptions::default().with_concurrency_limit(limit);
+    let poll = LongPoll::new(client, handler).with_options(options);
+    let handle = poll.get_handle();
+
+    spawn(async move {
+        sleep(Duration::from_millis(200)).await;
+        handle.shutdown().await;
+    });
+
+    poll.run().await;
+
+    let max = max_active.load(Ordering::Relaxed);
+    assert!(max <= limit, "Max concurrent was {}, but expected {}", max, limit);
 }


### PR DESCRIPTION
Having `spawn` in `loop` feels a bit risky, as in this case `LongPoll` can spawn unlimited count of tasks, which can lead to application hang on huge task amounts.

To protect `LongPoll` loop from spamming I've added `Semaphore` with also configuration entry in `LongPollOptions`. Also added test to cover updated logic.