### PR TITLE
Add `webpki` feature for lib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ serde_with = { version = "3", default-features = false, features = ["macros"] }
 shellwords = "1"
 tokio = { version = "1", features = ["fs", "sync", "time"] }
 tokio-util = { version = "0.7", features = ["codec"] }
-webpki-roots = { version = "1.0", optional = true }
+webpki-roots = { version = "1", optional = true }
 rustls = { version = "0.23", optional = true, default-features = false, features = ["std", "tls12"] }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,8 @@ serde_with = { version = "3", default-features = false, features = ["macros"] }
 shellwords = "1"
 tokio = { version = "1", features = ["fs", "sync", "time"] }
 tokio-util = { version = "0.7", features = ["codec"] }
+webpki-roots = { version = "1.0", optional = true }
+rustls = { version = "0.23", optional = true, default-features = false, features = ["std", "tls12"] }
 
 [dev-dependencies]
 dotenvy = "0.15"
@@ -56,6 +58,7 @@ toml = "1"
 
 [features]
 webhook = ["dep:axum"]
+webpki-roots = ["dep:webpki-roots", "dep:rustls"]
 
 [lints.rust]
 missing_docs = "warn"

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -40,11 +40,7 @@ impl Client {
         let client = {
             #[cfg(feature = "webpki-roots")]
             {
-                use rustls::RootCertStore;
-
-                let root_cert_store = RootCertStore {
-                    roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
-                };
+                let root_cert_store = rustls::RootCertStore::from_iter(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
 
                 let tls_config = rustls::ClientConfig::builder()
                     .with_root_certificates(root_cert_store)
@@ -59,7 +55,7 @@ impl Client {
             #[cfg(not(feature = "webpki-roots"))]
             {
                 HttpClientBuilder::new()
-                    .use_rustls_tls()
+                    .tls_backend_rustls()
                     .build()
                     .map_err(ClientError::BuildClient)?
             }

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -37,10 +37,33 @@ impl Client {
     where
         T: Into<String>,
     {
-        let client = HttpClientBuilder::new()
-            .use_rustls_tls()
-            .build()
-            .map_err(ClientError::BuildClient)?;
+        let client = {
+            #[cfg(feature = "webpki-roots")]
+            {
+                use rustls::RootCertStore;
+
+                let root_cert_store = RootCertStore {
+                    roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
+                };
+
+                let tls_config = rustls::ClientConfig::builder()
+                    .with_root_certificates(root_cert_store)
+                    .with_no_client_auth();
+
+                HttpClientBuilder::new()
+                    .tls_backend_preconfigured(tls_config)
+                    .build()
+                    .map_err(ClientError::BuildClient)?
+            }
+
+            #[cfg(not(feature = "webpki-roots"))]
+            {
+                HttpClientBuilder::new()
+                    .use_rustls_tls()
+                    .build()
+                    .map_err(ClientError::BuildClient)?
+            }
+        };
         Ok(Self::with_http_client(client, token))
     }
 


### PR DESCRIPTION
After `0.13` `reqwest` update `webpki`-related features were removed and it started use system-dependent certs verifier, so for `webpki` usage we need to explicitly initialize client with these roots.

The issue is that system-dependent certsare unavailable in `scratch` containers and some other slim containerized envs.

In current solution flows were simply separated by features and for `webpki` flow `webpki-roots` feature should be used.